### PR TITLE
Replace TO_CHAR function by DATE_FORMAT

### DIFF
--- a/moneyplex/moneyplex/server_scripts.py
+++ b/moneyplex/moneyplex/server_scripts.py
@@ -12,8 +12,8 @@ def moneyplex_export():
     --    ursprüngliche Variante:
     --    `tabPayment Request`.transaction_date AS "Datum",
     --    `tabPayment Request`.valuta AS "Valuta",
-        TO_CHAR(`tabPayment Request`.transaction_date, 'DD.MM.YYYY') AS "Datum",
-        TO_CHAR(`tabPayment Request`.valuta, 'DD.MM.YYYY') AS "Valuta",
+        DATE_FORMAT(`tabPayment Request`.transaction_date, '%d.%m.%Y') AS "Datum",
+        DATE_FORMAT(`tabPayment Request`.valuta, '%d.%m.%Y') AS "Valuta",
         `tabPayment Request`.supplier_name AS "Name",
         `tabPayment Request`.party_iban AS "Iban",
         `tabPayment Request`.party_bic AS "Bic",


### PR DESCRIPTION
Issue:
`pymysql.err.OperationalError: (1305, 'FUNCTION _4fe85efe789dbf37.TO_CHAR does not exist')`

![Captura de pantalla de 2023-09-21 09-05-34](https://github.com/phamos-eu/moneyplex/assets/6966715/6c6d2ce4-1c4b-4baa-81f4-8836e9bea026)

Solution: Replace TO_CHAR function by DATE_FORMAT