### PR TITLE
fix pandas issue with indexes

### DIFF
--- a/moneyplex/moneyplex/server_scripts.py
+++ b/moneyplex/moneyplex/server_scripts.py
@@ -39,7 +39,7 @@ def moneyplex_export():
     # save the .xlsx file
     filename = "moneyplex_export.xlsx"
     filepath = "{}/private/files/{}".format(frappe.utils.get_site_path(), filename)
-    df = pandas.DataFrame.from_records(result, index=['1', '2'])
+    df = pandas.DataFrame.from_records(result)
     names = list(df["name"])
     df.drop("name", axis=1, inplace=True)
     df.to_excel(filepath, index=False)


### PR DESCRIPTION
Issue:
![imagen](https://github.com/phamos-eu/moneyplex/assets/6966715/224182de-f303-424f-8356-302f18c277fd)
ValueError: Length of values (4) does not match length of index (2)

Solution: not use indexes when creating the dataframes